### PR TITLE
上傳圖片的功能做完了

### DIFF
--- a/app/Http/Controllers/ProductsController.php
+++ b/app/Http/Controllers/ProductsController.php
@@ -126,17 +126,19 @@ class ProductsController extends Controller
 
     public function uploadImg(EditRequest $request){
 
-
         $input = $request->all();
 
         if ($request->input('image_or_url') === 'image') {
-            if($request -> hasFile('ProductImg')){
-                $path = Storage::put('/public', $request->file('ProductImg'));
-                $path = explode('/', $path);
 
-                $input['ProductImg'] = $request->input('ProductImg');
+            $image = $request->file('ProductImg');
+
+            if($request -> hasFile('ProductImg')){
+                $path = Storage::put('/public', $image);
+                $input['ProductImg'] = basename($path);
+                logger($input['ProductImg']);
             }else{
-                dd("error");
+                dd("imageがないです");
+                $path = null;
             }
         } elseif ($request->input('image_or_url') === 'url') {
             $input['ProductImg'] = $request->input('ProductImgUrl');
@@ -155,6 +157,7 @@ class ProductsController extends Controller
             ]);
             DB::commit();
         }catch(Throwable $e){
+            dd($e->getMessage());
             DB::rollback();
             abort(500);
         }

--- a/resources/views/selectAdmin/DetailDatabese.blade.php
+++ b/resources/views/selectAdmin/DetailDatabese.blade.php
@@ -62,7 +62,7 @@
 
         <label for="ProductImg">イメージURL</label>
         <input id="ProductImg" name="ProductImg" value="{{ $products->products_img }}" type="text">
-        <img class="Detail_Database_imageURL" src="{{ '/storage/' . $products[ProductImg] }}" onerror="this.onerror=null; this.src='{{ $products->products_img }}'" alt="画像出力ミス">
+        <img class="Detail_Database_imageURL" src="{{ '/storage/' . $products->products_img }}" onerror="this.onerror=null; this.src='{{ $products->products_img }}'" alt="画像出力ミス">
         @if($errors->has('ProductImg'))
             <h3>{{ $errors->first('ProductImg') }}</h3>
         @endif


### PR DESCRIPTION
複習 : 怎麼上傳圖片檔案

1, 上傳圖片時一定需要執行php artisan storage:link的指令 .  這個storage有時候管理個人資訊 , 但是這次我希望把圖片檔案上傳伺服器之後再讀取那張圖片檔案 .  這樣操作伺服器時，使用 storage 資料夾可以比較方便地管理和處理上傳的圖片 . 

2, 執行剛剛的指令之後 , 在Controller之內輸入Storage::put('/public', [圖片檔案]) , 這行[圖片檔案]內只可輸入檔案 , 可能不可輸入str型態 , 只可file檔案 , 所以使用request->file()方法來讀取html的form之內的input的file , 然後create的方法來增加資訊

3, view裡面的img內src的程式是{{ '/storage/ . [連接資料庫的img]' }} , 寫入這行就可輸出storage裡的圖片檔案